### PR TITLE
Fixed url params for getFileFromJWT

### DIFF
--- a/api.go
+++ b/api.go
@@ -326,6 +326,12 @@ type tokenResponse struct {
 	ID       int
 }
 
+type fileUploadResponse struct {
+	RecordingId int
+	Success     bool
+	Messages    []string
+}
+
 // message gets the first message of the supplised tokenResponse if present
 // otherwise default of "unknown"
 func (r *tokenResponse) message() string {

--- a/db-test-seed.sql
+++ b/db-test-seed.sql
@@ -4,3 +4,5 @@ INSERT INTO "Groups" ("id","groupname","createdAt","updatedAt") VALUES (DEFAULT,
 --test-password
 INSERT INTO "Devices" ("id","devicename","password","public","createdAt","updatedAt","GroupId") VALUES (DEFAULT,'test-device','$2a$10$LWL.Sr0767v0RmWqcgAKduBXSE2G9T2oIn.W5V1ohtgZQA4kKgR06',false,'2019-03-14 20:17:45.636 +00:00','2019-03-14 20:17:45.636 +00:00',1);
 
+--test-user
+INSERT INTO "Users" (username, email, password, "globalPermission", "createdAt", "updatedAt") VALUES ('go-api-user-test', 'go-api@email.com', '$2a$10$gYAi/taZNA5y5rN8cgu0oOW30iHxTXXDoAwDv7cnyTDPPyWZK847K', 'read', now(), now());


### PR DESCRIPTION
Because the URL parameters were set as the path the `?` was getting URL encoded, breaking the link.