### PR TITLE
Separate register function

### DIFF
--- a/api.go
+++ b/api.go
@@ -48,11 +48,10 @@ type CacophonyDevice struct {
 }
 
 type CacophonyAPI struct {
-	device         *CacophonyDevice
-	httpClient     *http.Client
-	serverURL      string
-	token          string
-	justRegistered bool
+	device     *CacophonyDevice
+	httpClient *http.Client
+	serverURL  string
+	token      string
 }
 
 // joinURL creates an absolute url with supplied baseURL, and all paths
@@ -80,10 +79,6 @@ func (api *CacophonyAPI) getRegURL() string {
 
 func (api *CacophonyAPI) Password() string {
 	return api.device.password
-}
-
-func (api *CacophonyAPI) JustRegistered() bool {
-	return api.justRegistered
 }
 
 // apiFromConfig creates CacophonyAPI from config. The API will need to
@@ -279,7 +274,6 @@ func (api *CacophonyAPI) register() error {
 	api.device.id = respData.ID
 	api.device.password = password
 	api.token = respData.Token
-	api.justRegistered = true
 
 	return nil
 }

--- a/api.go
+++ b/api.go
@@ -131,8 +131,9 @@ func apiFromConfig() (*CacophonyAPI, *LockSafeConfig, error) {
 	return api, lockSafeConfig, err
 }
 
-// ApiFromAuthenticate will get a API from the configuration file
-func ApiFromAuthenticate() (*CacophonyAPI, error) {
+// New will get an API from the configuration and authenticate. Will return an
+// error if the device has not been registered yet.
+func New() (*CacophonyAPI, error) {
 	api, lockSafeConfig, err := apiFromConfig()
 	if err != nil {
 		return nil, err
@@ -154,7 +155,9 @@ func ApiFromAuthenticate() (*CacophonyAPI, error) {
 	return api, nil
 }
 
-func ApiFromRegister() (*CacophonyAPI, error) {
+// Register will reutrn an API after regsitering. If the device is already
+// registered it will return an error.
+func Register() (*CacophonyAPI, error) {
 	api, lockSafeConfig, err := apiFromConfig()
 	if err != nil {
 		return nil, err

--- a/api.go
+++ b/api.go
@@ -143,7 +143,7 @@ func New() (*CacophonyAPI, error) {
 	return api, nil
 }
 
-// Register will check that there is not already deice config files, will then
+// Register will check that there is not already device config files, will then
 // register with the given parameters and then save them in new config files.
 func Register(devicename string, password string, group string, apiURL string) (*CacophonyAPI, error) {
 	url, err := url.Parse(apiURL)
@@ -225,7 +225,7 @@ func Register(devicename string, password string, group string, apiURL string) (
 func (api *CacophonyAPI) authenticate() error {
 
 	if api.device.password == "" {
-		return &notRegisteredError{}
+		return notRegisteredError
 	}
 
 	data := map[string]interface{}{
@@ -523,13 +523,8 @@ func (api *CacophonyAPI) GetSchedule() ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-type notRegisteredError struct{}
-
-func (e *notRegisteredError) Error() string {
-	return "device is not registered"
-}
+var notRegisteredError = errors.New("device is not registered")
 
 func IsNotRegisteredError(err error) bool {
-	_, ok := err.(*notRegisteredError)
-	return ok
+	return err == notRegisteredError
 }

--- a/api.go
+++ b/api.go
@@ -180,7 +180,7 @@ func Register() (*CacophonyAPI, error) {
 func (api *CacophonyAPI) authenticate() error {
 
 	if api.device.password == "" {
-		return errors.New("no password set")
+		return &notRegisteredError{}
 	}
 
 	data := map[string]interface{}{
@@ -519,4 +519,19 @@ func (api *CacophonyAPI) GetSchedule() ([]byte, error) {
 	defer resp.Body.Close()
 
 	return ioutil.ReadAll(resp.Body)
+}
+
+type notRegisteredError struct{}
+
+func (e *notRegisteredError) Error() string {
+	return "device is not registered"
+}
+
+func IsNotRegisteredError(e interface{}) bool {
+	switch e.(type) {
+	case *notRegisteredError:
+		return true
+	default:
+		return false
+	}
 }

--- a/api.go
+++ b/api.go
@@ -81,6 +81,10 @@ func (api *CacophonyAPI) Password() string {
 	return api.device.password
 }
 
+func (api *CacophonyAPI) DeviceID() int {
+	return api.device.id
+}
+
 // apiFromConfig creates CacophonyAPI from config. The API will need to
 // be registered or be authenticated before used.
 func apiFromConfig() (*CacophonyAPI, *LockSafeConfig, error) {

--- a/api_test.go
+++ b/api_test.go
@@ -329,12 +329,15 @@ func TestRegisterAndNew(t *testing.T) {
 	assert.Equal(t, api2.device.group, defaultGroup, "group does not match what was registered with")
 	assert.Equal(t, api2.Password(), password, "password does not match what was registered with")
 
+	reader := strings.NewReader(rawThermalData)
+	assert.NoError(t, api2.UploadThermalRaw(reader), "check that api can upload recordings")
+
 	_, err = Register(name+"a", defaultPassword, defaultGroup, apiURL)
 	assert.Error(t, err, "must not be able to register when the device is already registered")
 }
 
 func TestIsNotRegisteredError(t *testing.T) {
-	assert.True(t, IsNotRegisteredError(&notRegisteredError{}))
+	assert.True(t, IsNotRegisteredError(notRegisteredError))
 	assert.False(t, IsNotRegisteredError(errors.New("a error")))
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -307,42 +307,30 @@ func TestMultipleRegistrations(t *testing.T) {
 	}
 }
 
-func TestAuthenticateAndRegister(t *testing.T) {
+func TestRegisterAndNew(t *testing.T) {
 	Fs = afero.NewMemMapFs()
+
 	_, err := New()
 	assert.Error(t, err, "error must be thrown if not yet registered")
 	assert.True(t, IsNotRegisteredError(err))
-
-	name := randString(20)
-	api, err := Register(name, defaultPassword, defaultGroup, apiURL)
-	require.NoError(t, err, "should not error first time registering")
-	deviceID := api.DeviceID()
-
-	api, err = New()
-	assert.NoError(t, err, "must be able to authenticate after register")
-	assert.Equal(t, deviceID, api.DeviceID())
-
-	api, err = Register(name+"a", defaultPassword, defaultGroup, apiURL)
-	assert.Error(t, err, "must not be able to register twice")
-}
-
-func TestRegisterAndNew(t *testing.T) {
-	Fs = afero.NewMemMapFs()
 
 	name := randString(10)
 	password := randString(10)
 	api1, err := Register(name, password, defaultGroup, apiURL)
 	require.NoError(t, err, "failed to register")
-	assert.Equal(t, api1.device.name, name)
-	assert.Equal(t, api1.device.group, defaultGroup)
-	assert.Equal(t, api1.Password(), password)
+	assert.Equal(t, api1.device.name, name, "name does not match what was registered with")
+	assert.Equal(t, api1.device.group, defaultGroup, "group does not match what was registered with")
+	assert.Equal(t, api1.Password(), password, "password does not match what was registered with")
 
 	api2, err := New()
 	require.NoError(t, err, "failed to login after register")
-	assert.Equal(t, api1.DeviceID(), api2.DeviceID())
-	assert.Equal(t, api2.device.name, name)
-	assert.Equal(t, api2.device.group, defaultGroup)
-	assert.Equal(t, api2.Password(), password)
+	assert.Equal(t, api1.DeviceID(), api2.DeviceID(), "deviceID does not match what was registered with")
+	assert.Equal(t, api2.device.name, name, "name does not match what was registered with")
+	assert.Equal(t, api2.device.group, defaultGroup, "group does not match what was registered with")
+	assert.Equal(t, api2.Password(), password, "password does not match what was registered with")
+
+	_, err = Register(name+"a", defaultPassword, defaultGroup, apiURL)
+	assert.Error(t, err, "must not be able to register when the device is already registered")
 }
 
 func TestIsNotRegisteredError(t *testing.T) {

--- a/api_test.go
+++ b/api_test.go
@@ -306,14 +306,14 @@ func createTestConfig(t *testing.T) string {
 // TestConfigFile test registered config is created with deviceid and password
 func TestConfigFile(t *testing.T) {
 	_ = createTestConfig(t)
-	_, err := ApiFromRegister()
+	_, err := Register()
 	assert.NoError(t, err)
 	lockSafeConfig := NewLockSafeConfig(RegisteredConfigPath)
 	config, err := lockSafeConfig.Read()
 	require.NoError(t, err, "Must be able to read "+RegisteredConfigPath)
 	assert.NotEmpty(t, config.Password)
 
-	_, err = ApiFromAuthenticate()
+	_, err = New()
 	assert.NoError(t, err)
 }
 
@@ -324,7 +324,7 @@ func runMultipleRegistrations(configFile string, count int) (int, chan string) {
 
 	for i := 0; i < count; i++ {
 		go func() {
-			api, err := ApiFromAuthenticate()
+			api, err := New()
 			if err != nil {
 				messages <- err.Error()
 			} else {
@@ -346,16 +346,16 @@ func TestMultipleRegistrations(t *testing.T) {
 }
 
 func TestAuthenticateAndRegister(t *testing.T) {
-	_, err := ApiFromAuthenticate()
+	_, err := New()
 	assert.Error(t, err, "error must be thrown if not yet registered")
 
-	_, err = ApiFromRegister()
+	_, err = Register()
 	assert.NoError(t, err, "no error first time registering")
 
-	_, err = ApiFromAuthenticate()
+	_, err = New()
 	assert.NoError(t, err, "must be able to authenticate after register")
 
-	_, err = ApiFromRegister()
+	_, err = Register()
 	assert.Error(t, err, "must not be able to register twice")
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -189,10 +189,8 @@ func TestAPIRegistration(t *testing.T) {
 
 	err = api.register()
 	assert.NoError(t, err)
-	assert.True(t, api.JustRegistered())
 	assert.NotEqual(t, "", api.device.password)
 	assert.NotEqual(t, "", api.token)
-	assert.True(t, api.JustRegistered())
 
 	err = api.authenticate()
 	assert.NoError(t, err)
@@ -384,7 +382,6 @@ func getAPI(url, password string, register bool) *CacophonyAPI {
 	if register {
 		api.device.password = randString(20)
 		api.token = "tok-" + randString(20)
-		api.justRegistered = true
 		api.device.id = 1
 	}
 	return api

--- a/api_test.go
+++ b/api_test.go
@@ -349,11 +349,13 @@ func TestAuthenticateAndRegister(t *testing.T) {
 	assert.Error(t, err, "error must be thrown if not yet registered")
 	assert.True(t, IsNotRegisteredError(err))
 
-	_, err = Register()
+	api, err := Register()
 	assert.NoError(t, err, "no error first time registering")
+	deviceID := api.DeviceID()
 
-	_, err = New()
+	api, err = New()
 	assert.NoError(t, err, "must be able to authenticate after register")
+	assert.Equal(t, deviceID, api.DeviceID())
 
 	_, err = Register()
 	assert.Error(t, err, "must not be able to register twice")

--- a/api_test.go
+++ b/api_test.go
@@ -18,6 +18,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -348,6 +349,7 @@ func TestMultipleRegistrations(t *testing.T) {
 func TestAuthenticateAndRegister(t *testing.T) {
 	_, err := New()
 	assert.Error(t, err, "error must be thrown if not yet registered")
+	assert.True(t, IsNotRegisteredError(err))
 
 	_, err = Register()
 	assert.NoError(t, err, "no error first time registering")
@@ -357,6 +359,11 @@ func TestAuthenticateAndRegister(t *testing.T) {
 
 	_, err = Register()
 	assert.Error(t, err, "must not be able to register twice")
+}
+
+func TestIsNotRegisteredError(t *testing.T) {
+	assert.True(t, IsNotRegisteredError(&notRegisteredError{}))
+	assert.False(t, IsNotRegisteredError(errors.New("a error")))
 }
 
 // getAPI returns a CacophonyAPI for testing purposes using provided url and password with random name

--- a/config.go
+++ b/config.go
@@ -167,7 +167,7 @@ func (lockSafeConfig *LockSafeConfig) Write(deviceID int, password string) error
 	if lockSafeConfig.fileLock.Locked() {
 		err = afero.WriteFile(Fs, lockSafeConfig.filename, buf, 0600)
 	} else {
-		return fmt.Errorf("WritePassword could not get file lock %v", lockSafeConfig.filename)
+		return fmt.Errorf("file is not locked %v", lockSafeConfig.filename)
 	}
 	return err
 }

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ func GetConfig(filePath string) (*Config, error) {
 	if exists, err := afero.Exists(Fs, filePath); err != nil {
 		return nil, err
 	} else if !exists {
-		return nil, &notRegisteredError{}
+		return nil, notRegisteredError
 	}
 
 	conf := &Config{
@@ -97,14 +97,7 @@ type PrivateConfig struct {
 
 //Validate checks supplied Config contains the required data
 func (conf *PrivateConfig) IsValid() bool {
-	if conf.Password == "" {
-		return false
-	}
-
-	if conf.DeviceID == 0 {
-		return false
-	}
-	return true
+	return conf.Password != "" && conf.DeviceID != 0
 }
 
 const (


### PR DESCRIPTION
This replaces `NewAPI` that would register or authenticate depending on if there were config files into `New` that will just read the config file and authenticate (get JWT from the server) and `Register` that will (if there are no config files already) will register to the server as a new device and make new config files.