### PR TITLE
fix panic when processing an empty line in the hostname file

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -50,7 +50,8 @@ const (
 	defaultuserPassword = "test-user-password"
 	filesURL            = "/files"
 	hostsFileString     = `127.0.0.1 raspberrypi
-::1 localhost`
+::1 localhost
+`
 )
 
 var responseHeader = http.StatusOK

--- a/config.go
+++ b/config.go
@@ -110,7 +110,8 @@ func updateHostnameFiles(hostname string) error {
 	lines := strings.Split(string(input), "\n")
 
 	for i, line := range lines {
-		if strings.Fields(line)[0] == "127.0.0.1" {
+		fields := strings.Fields(line)
+		if len(fields) >= 1 && fields[0] == "127.0.0.1" {
 			lines[i] = fmt.Sprintf(hostsFileFormat, hostname)
 		}
 	}


### PR DESCRIPTION
an empty line in the hostsname file would cause a panic when registering or renaming