### PR TITLE
Use nano timestamp

### DIFF
--- a/api.go
+++ b/api.go
@@ -523,7 +523,7 @@ func handleHTTPResponse(resp *http.Response) error {
 
 //formatTimestamp to time.RFC3339 format
 func formatTimestamp(t time.Time) string {
-	return t.UTC().Format(time.RFC3339)
+	return t.UTC().Format(time.RFC3339Nano)
 }
 
 func isHTTPSuccess(code int) bool {

--- a/api.go
+++ b/api.go
@@ -521,7 +521,7 @@ func handleHTTPResponse(resp *http.Response) error {
 	return nil
 }
 
-//formatTimestamp to time.RFC3339 format
+//formatTimestamp to time.RFC3339Nano format
 func formatTimestamp(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)
 }


### PR DESCRIPTION
- Some processes can change the config multiple times in a second so to know what one is most recent a higher resolution than just seconds is needed when reporting events.